### PR TITLE
Remove unnecessarily saving name in room's players and fix seat order and other

### DIFF
--- a/src/app/[room]/page.tsx
+++ b/src/app/[room]/page.tsx
@@ -34,15 +34,12 @@ export default function RoomPage() {
       room.id,
       async (activeUsers) => {
         const fetchedUsers: Array<User | null> = await Promise.all(
-          activeUsers
+          room.players
             .filter(
-              (userId) =>
-                !!room.players //
-                  .find((player) => player.userId === userId),
+              (player) =>
+                !!activeUsers.find((active) => active === player.userId) || room.votes[player.userId] != null,
             )
-            .map(async (userId) => {
-              return await getUserById(userId);
-            }),
+            .map((player) => getUserById(player.userId)),
         );
 
         setActivePlayers(

--- a/src/lib/dbQueries.ts
+++ b/src/lib/dbQueries.ts
@@ -60,21 +60,13 @@ export async function joinRoom(
   const { players } = PlayerOnlySchema.parse(docSnap.data());
   const playerIndex = players.findIndex((player) => player.userId === user.id);
 
-  if (
-    playerIndex !== -1 &&
-    players[playerIndex].displayName === user.displayName
-  ) {
+  // already in room
+  if (playerIndex !== -1) {
     return;
   }
 
-  if (playerIndex === -1) {
-    players.push({ userId: user.id, displayName: user.displayName });
-  } else {
-    players[playerIndex].displayName = user.displayName;
-  }
-
   await updateDoc(docRef, <z.infer<typeof PlayerOnlySchema>>{
-    players,
+    players: [...players, { userId: user.id }],
   });
 }
 
@@ -186,6 +178,7 @@ export async function createUser(user: Omit<User, 'id'>) {
 
 /**
  * @param id Document id
+ * @param callback
  */
 export function onUserChanged(id: string, callback: (user: User) => void) {
   return onSnapshot(doc(db, 'users', id), (docSnap) => {

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -13,11 +13,8 @@ export const RoomSchema = z.object({
   id: z.string(),
   name: z.string(),
   cards: z.string().array(),
-  players: z
-    .object({
-      userId: z.string(),
-      displayName: z.string().nullable(),
-    })
+  players: z //
+    .object({ userId: z.string() })
     .array()
     .optional()
     .default([]),


### PR DESCRIPTION
Removing the unused displayName property in `room.players` still retained as an array of object rathern than an array of ids as it would affect the prod db. 

Fix seat order to be basing it in saved players from firestore instead of realtime db.

Fix inactive players that have voted, and were incorrectly filtered out. Making it disappear in the room.